### PR TITLE
Minor fixes

### DIFF
--- a/pages/events.md
+++ b/pages/events.md
@@ -14,7 +14,6 @@ This method is twice as fast as Method B, so it is the preffered usage.
 ```
 
 ### Method B: From The Component
-This method is twice as fast as Method B, so it is the preffered usage.
 
 ```php
 $this->emit('showModal');

--- a/pages/registering_components.md
+++ b/pages/registering_components.md
@@ -19,7 +19,7 @@ class AppServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        Livewire::component('counter', \App\Http\Livewire\Counter::class);
+        \Livewire::component('counter', \App\Http\Livewire\Counter::class);
     }
 }
 ```


### PR DESCRIPTION
Fixed namespace of Livewire facade when registering components. Otherwise the user will receive the error:

> Class 'App\Providers\Livewire' not found

Also removed the duplicated message **This method is twice as fast as Method B, so it is the preffered usage.** under the Method B itself.