### PR TITLE
Fix component extends

### DIFF
--- a/build_production/docs/component-basics/index.html
+++ b/build_production/docs/component-basics/index.html
@@ -280,7 +280,9 @@
 <p>The <code>render()</code> method is expected to return a Blade view, therefore, you can compare it to writing a controller method. Here is an example:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ShowPosts.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class ShowPosts extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ShowPosts.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ShowPosts extends Component
 {
     public function render()
     {
@@ -334,7 +336,9 @@ Here are some common things you might forget ARE NOT possible in Livewire:
 <p>Similar to Jobs or Mailables, properties marked as <code>public</code> are automatically made available in the Blade view. For example:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">HelloWorld.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class HelloWorld extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">HelloWorld.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class HelloWorld extends Component
 {
     public $message = 'Hello World';
 
@@ -360,7 +364,9 @@ Here are some common things you might forget ARE NOT possible in Livewire:
 <p>Unfortunately, this is illegal in PHP. However, you can initialize properties at run-time using the <code>mount</code> method/hook in Livewire. For example:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">HelloWorld.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class HelloWorld extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">HelloWorld.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class HelloWorld extends Component
 {
     public $message;
 

--- a/build_production/docs/data-binding/index.html
+++ b/build_production/docs/data-binding/index.html
@@ -272,7 +272,9 @@
 <p>If you've used front-end frameworks like Angular, React, or Vue, you are already familiar with this concept. However, if you are new to this concept, allow me to demonstrate.</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">MyNameIs</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class MyNameIs extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">MyNameIs</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class MyNameIs extends Component
 {
     public $name;
 
@@ -343,7 +345,9 @@
 <p>In those cases, use the <code>lazy</code> directive modifier to listen for the native &quot;change&quot; event.</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">MyNameIs</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class MyNameIs extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">MyNameIs</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class MyNameIs extends Component
 {
     public $name;
 

--- a/build_production/docs/events/index.html
+++ b/build_production/docs/events/index.html
@@ -285,7 +285,9 @@
 <p>Event listeners are registered in the <code>$listeners</code> property of your Livewire components.</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">Modal</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class Modal extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">Modal</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class Modal extends Component
 {
     public $isOpen = false;
 
@@ -378,7 +380,9 @@ window.livewire.on('incremented', count =&gt; {
 <p>With Livewire however, all you have to do is register it in your <code>$listeners</code> property, with some special syntax to designate it's from Echo.</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">OrderTracker</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class OrderTracker extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">OrderTracker</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class OrderTracker extends Component
 {
     public $showNewOrderNotication = false;
 

--- a/build_production/docs/input-validation/index.html
+++ b/build_production/docs/input-validation/index.html
@@ -272,7 +272,9 @@
 <p>Consider the following Livewire component:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class ContactForm extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 
@@ -298,7 +300,9 @@
 <p>We can add validation to this form almost exactly how you would in a controller. Take a look:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class ContactForm extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 
@@ -339,7 +343,9 @@
 <p>For example:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class ContactForm extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 

--- a/build_production/docs/lifecycle-hooks/index.html
+++ b/build_production/docs/lifecycle-hooks/index.html
@@ -301,7 +301,9 @@
 </tbody>
 </table>
 <div class="rounded-lg bg-gray-800 mb-12">
-    <pre class="scrollbar-none"><code class="scrolling-touch language-php">class HelloWorld extends LivewireComponent
+    <pre class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class HelloWorld extends Component
 {
     public $foo;
 

--- a/build_production/docs/quickstart/index.html
+++ b/build_production/docs/quickstart/index.html
@@ -332,7 +332,9 @@ class Counter extends Component
 <p>Replace the generated content of the <code>counter</code> component class and view with the following:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">app/Http/Livewire/Counter.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class Counter extends Component
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">app/Http/Livewire/Counter.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class Counter extends Component
 {
     public $count = 0;
 

--- a/build_production/docs/redirecting/index.html
+++ b/build_production/docs/redirecting/index.html
@@ -272,7 +272,9 @@
 <p>You may want to redirect from inside a Livewire component to another route in your app. Livewire offers a simple <code>$this-&gt;redirect()</code> method to accomplish this:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class ContactForm extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">ContactForm.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 

--- a/build_production/docs/rendering-components/index.html
+++ b/build_production/docs/rendering-components/index.html
@@ -275,7 +275,9 @@
     <pre class="scrollbar-none"><code class="scrolling-touch language-php">@livewire('show-contact', $contactId)</code></pre>
 </div>
 <div class="rounded-lg bg-gray-800 mb-12">
-    <pre class="scrollbar-none"><code class="scrolling-touch language-php">class ShowContact extends LivewireComponent
+    <pre class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ShowContact extends Component
 {
     public $name;
     public $email;

--- a/build_production/docs/spa-mode/index.html
+++ b/build_production/docs/spa-mode/index.html
@@ -345,7 +345,9 @@ Route::livewire('/home', 'counter')
 </div>
 <p><strong>App\Http\Livewire\ShowContact.php</strong></p>
 <div class="rounded-lg bg-gray-800 mb-12">
-    <pre class="scrollbar-none"><code class="scrolling-touch language-php">class ShowContact extends LivewireComponent
+    <pre class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ShowContact extends Component
 {
     public $name;
     public $email;
@@ -370,7 +372,9 @@ Route::livewire('/home', 'counter')
 </div>
 <p><strong>App\Http\Livewire\ShowContact.php</strong></p>
 <div class="rounded-lg bg-gray-800 mb-12">
-    <pre class="scrollbar-none"><code class="scrolling-touch language-php">class ShowContact extends LivewireComponent
+    <pre class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class ShowContact extends Component
 {
     public $contact;
 

--- a/build_production/docs/testing/index.html
+++ b/build_production/docs/testing/index.html
@@ -277,7 +277,9 @@
 <p>For these demonstrations, we will be using a simple Counter component like the following:</p>
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">Counter.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class Counter extends LivewireComponent
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">Counter.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class Counter extends Component
 {
     public $count = 0;
 

--- a/build_production/index.html
+++ b/build_production/index.html
@@ -175,7 +175,9 @@
         <div class="">
 <div class="rounded-lg bg-gray-800 overflow-hidden mb-12">
         <div class="relative py-1">
-         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">App\Http\Livewire\Counter.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">class Counter extends Component
+         <span class="select-none absolute font-bold px-4 pt-1 right-0 text-gray-500 text-sm hidden md:block">App\Http\Livewire\Counter.php</span>         <pre style="margin: 0;" class="scrollbar-none"><code class="scrolling-touch language-php">use Livewire\Component;
+
+class Counter extends Component
 {
     public $count = 0;
 

--- a/source/docs/component-basics.blade.md
+++ b/source/docs/component-basics.blade.md
@@ -24,7 +24,9 @@ The `render()` method is expected to return a Blade view, therefore, you can com
 ])
 @slot('class')
 @verbatim
-class ShowPosts extends LivewireComponent
+use Livewire\Component;
+
+class ShowPosts extends Component
 {
     public function render()
     {
@@ -83,7 +85,9 @@ Similar to Jobs or Mailables, properties marked as `public` are automatically ma
 ])
 @slot('class')
 @verbatim
-class HelloWorld extends LivewireComponent
+use Livewire\Component;
+
+class HelloWorld extends Component
 {
     public $message = 'Hello World';
 
@@ -120,7 +124,9 @@ Unfortunately, this is illegal in PHP. However, you can initialize properties at
     'viewName' => 'hello-world.blade.php',
 ])
 @slot('class')
-class HelloWorld extends LivewireComponent
+use Livewire\Component;
+
+class HelloWorld extends Component
 {
     public $message;
 

--- a/source/docs/data-binding.blade.md
+++ b/source/docs/data-binding.blade.md
@@ -15,7 +15,9 @@ If you've used front-end frameworks like Angular, React, or Vue, you are already
 ])
 @slot('class')
 @verbatim
-class MyNameIs extends LivewireComponent
+use Livewire\Component;
+
+class MyNameIs extends Component
 {
     public $name;
 
@@ -80,7 +82,9 @@ In those cases, use the `lazy` directive modifier to listen for the native "chan
 ])
 @slot('class')
 @verbatim
-class MyNameIs extends LivewireComponent
+use Livewire\Component;
+
+class MyNameIs extends Component
 {
     public $name;
 

--- a/source/docs/events.blade.md
+++ b/source/docs/events.blade.md
@@ -31,7 +31,9 @@ Event listeners are registered in the `$listeners` property of your Livewire com
 
 @codeComponent(['className' => 'Modal'])
 @slot('class')
-class Modal extends LivewireComponent
+use Livewire\Component;
+
+class Modal extends Component
 {
     public $isOpen = false;
 
@@ -125,7 +127,9 @@ With Livewire however, all you have to do is register it in your `$listeners` pr
 
 @codeComponent(['className' => 'OrderTracker'])
 @slot('class')
-class OrderTracker extends LivewireComponent
+use Livewire\Component;
+
+class OrderTracker extends Component
 {
     public $showNewOrderNotication = false;
 

--- a/source/docs/input-validation.blade.md
+++ b/source/docs/input-validation.blade.md
@@ -15,7 +15,9 @@ Consider the following Livewire component:
 ])
 @slot('class')
 @verbatim
-class ContactForm extends LivewireComponent
+use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 
@@ -50,7 +52,9 @@ We can add validation to this form almost exactly how you would in a controller.
 ])
 @slot('class')
 @verbatim
-class ContactForm extends LivewireComponent
+use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 
@@ -100,7 +104,9 @@ For example:
 ])
 @slot('class')
 @verbatim
-class ContactForm extends LivewireComponent
+use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 

--- a/source/docs/lifecycle-hooks.blade.md
+++ b/source/docs/lifecycle-hooks.blade.md
@@ -18,7 +18,9 @@ updatingFoo | Runs before a property called `$foo` is updated
 updatedFoo | Runs after a property called `$foo` is updated
 
 @code(['lang' => 'php'])
-class HelloWorld extends LivewireComponent
+use Livewire\Component;
+
+class HelloWorld extends Component
 {
     public $foo;
 

--- a/source/docs/quickstart.blade.md
+++ b/source/docs/quickstart.blade.md
@@ -106,6 +106,8 @@ Replace the generated content of the `counter` component class and view with the
 ])
 @slot('class')
 @verbatim
+use Livewire\Component;
+
 class Counter extends Component
 {
     public $count = 0;

--- a/source/docs/redirecting.blade.md
+++ b/source/docs/redirecting.blade.md
@@ -15,7 +15,9 @@ You may want to redirect from inside a Livewire component to another route in yo
 ])
 @slot('class')
 @verbatim
-class ContactForm extends LivewireComponent
+use Livewire\Component;
+
+class ContactForm extends Component
 {
     public $email;
 

--- a/source/docs/rendering-components.blade.md
+++ b/source/docs/rendering-components.blade.md
@@ -19,7 +19,9 @@ You can pass data into a component by passing additional parameters into the `@l
 
 @code(['lang' => 'php'])
 @verbatim
-class ShowContact extends LivewireComponent
+use Livewire\Component;
+
+class ShowContact extends Component
 {
     public $name;
     public $email;

--- a/source/docs/spa-mode.blade.md
+++ b/source/docs/spa-mode.blade.md
@@ -104,7 +104,9 @@ Route::livewire('/contact/{id}', 'show-contact');
 
 **App\Http\Livewire\ShowContact.php**
 @code(['lang' => 'php'])
-class ShowContact extends LivewireComponent
+use Livewire\Component;
+
+class ShowContact extends Component
 {
     public $name;
     public $email;
@@ -134,7 +136,9 @@ Route::livewire('/contact/{user}', 'show-contact');
 
 **App\Http\Livewire\ShowContact.php**
 @code(['lang' => 'php'])
-class ShowContact extends LivewireComponent
+use Livewire\Component;
+
+class ShowContact extends Component
 {
     public $contact;
 

--- a/source/docs/testing.blade.md
+++ b/source/docs/testing.blade.md
@@ -19,7 +19,9 @@ For these demonstrations, we will be using a simple Counter component like the f
 ])
 @slot('class')
 @verbatim
-class Counter extends LivewireComponent
+use Livewire\Component;
+
+class Counter extends Component
 {
     public $count = 0;
 

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -105,6 +105,8 @@
 
         <div class="">
 @codeComponent(['className' => 'App\Http\Livewire\Counter.php', 'viewName' => 'resources/views/livewire/counter.blade.php']) @slot('class') @verbatim
+use Livewire\Component;
+
 class Counter extends Component
 {
     public $count = 0;


### PR DESCRIPTION
Rename all `LivewireComponent` occurrences to `Component` and add import statements.

The [current version](https://livewire-framework.com/docs/rendering-components/) of the docs say you need to extend `LivewireComponent`
![extends LivewireComponent](https://user-images.githubusercontent.com/6857732/59922185-724eeb00-9406-11e9-9304-477c7e08f983.png)

But it should be extending `Component` instead:
![Screen Shot 2019-06-21 at 09 24 34](https://user-images.githubusercontent.com/6857732/59922226-9c081200-9406-11e9-9459-eaa0ceb623e1.png)


\* The colors are off because of compression, I didn't change that :p