### PR TITLE
added redirect /docs => /docs/quickstart

### DIFF
--- a/source/docs/index.blade.php
+++ b/source/docs/index.blade.php
@@ -1,0 +1,5 @@
+@extends('_layouts.base')
+
+@push('meta')
+<meta http-equiv="refresh" content="0;URL='/docs/quickstart'" />
+@endpush


### PR DESCRIPTION
I always type `/docs` out and get a 404 error page. This just redirects it to quickstart 👍 