### PR TITLE
add `start()` call to SPA docs

### DIFF
--- a/source/docs/spa-mode.blade.md
+++ b/source/docs/spa-mode.blade.md
@@ -21,6 +21,7 @@ Turbolinks.start()
 document.addEventListener('turbolinks:load', () => {
     if (! window.livewire) {
         window.livewire = new Livewire()
+        window.livewire.start()
     } else {
         window.livewire.restart()
     }


### PR DESCRIPTION
If I understood the https://github.com/calebporzio/livewire/releases/tag/v0.2.2 changelog and https://github.com/calebporzio/livewire/commit/6ba2eb928778b3b3f5bf5aba5d9a49582ee43bd0#diff-afbbb6430c73cf50cafea78549c61fd9R81 correct those docs need to be updated.